### PR TITLE
Add musl support binary on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           assets: ./*.zip
+  
+  release-linux-musl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch dependencies
+        run: cargo fetch
+      - name: Build in release mode
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --frozen --target x86_64-unknown-linux-musl
+      - name: Add the version tag to the binary name
+        run: |
+          VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
+          TARGET=x86_64-unknown-linux-musl
+          NAME=mask-$VERSION_TAG-$TARGET
+          mkdir $NAME
+          mv ./target/$TARGET/release/mask ./$NAME/mask
+          chmod +x ./$NAME/mask
+          zip -r $NAME.zip $NAME
+      - name: Attach the binary to the release
+        uses: ./.github/actions/attach-release-assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          assets: ./*.zip
 
   release-macos-aarch64:
     runs-on: macos-latest


### PR DESCRIPTION
<!--
Please review our Contribution Guidelines (CONTRIBUTING.md) before creating an issue or submitting a PR 🙌
-->

### Which issue does this fix?
<!-- Replace {ISSUE} with the issue number you've fixed -->

Closes #93 

### Describe the solution
Updates `release.yml` file to include a new asset on release for a binary built with the `musl` library. This enables direct download and execution on OSs with `musl` library like `alpine`.

It should attach the assets template similar to the following:
`mask-VERSION-x86_64-unknown-linux-musl.zip`

Tested this on my own fork of mask, musl release job can be viewed here:
https://github.com/8Mobius8/mask/actions/runs/3814878606/jobs/6489495643

I additionally tested the binary on the basic alpine image:
```file
$ docker run -it alpine
/ # wget https://github.com/8Mobius8/mask/releases/download/release-test-musl/mask-release-test-musl-x86_64-unknown-linu
x-musl.zip
Connecting to github.com (140.82.114.4:443)
Connecting to objects.githubusercontent.com (185.199.109.133:443)
saving to 'mask-release-test-musl-x86_64-unknown-linux-musl.zip'
mask-release-test-mu 100% |************************************************************************| 1514k  0:00:00 ETA
'mask-release-test-musl-x86_64-unknown-linux-musl.zip' saved
/ # unzip mask-release-test-musl-x86_64-unknown-linux-musl.zip
Archive:  mask-release-test-musl-x86_64-unknown-linux-musl.zip
   creating: mask-release-test-musl-x86_64-unknown-linux-musl/
  inflating: mask-release-test-musl-x86_64-unknown-linux-musl/mask
/ # ./mask-release-test-musl-x86_64-unknown-linux-musl/mask --version
WARNING: no maskfile.md found
mask 0.11.2
/ # file ./mask-release-test-musl-x86_64-unknown-linux-musl/mask
./mask-release-test-musl-x86_64-unknown-linux-musl/mask: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, BuildID[sha1]=3c5a542679fb31aa65165b983ae33686c66fad36, with debug_info, not stripped
```


