### PR TITLE
Improve error message for invalid executors

### DIFF
--- a/mask/tests/supported_runtimes_test.rs
+++ b/mask/tests/supported_runtimes_test.rs
@@ -26,6 +26,28 @@ echo "this won't do anything..."
         .failure();
 }
 
+#[test]
+fn custom_not_found_error_if_program_not_found() {
+    let (_temp, maskfile_path) = common::maskfile(
+        r#"
+## missing
+~~~notfound
+echo "this won't do anything..."
+~~~
+"#,
+    );
+
+    common::run_mask(&maskfile_path)
+        .command("missing")
+        .assert()
+        .code(1)
+        .stderr(contains(format!(
+            "{} program 'notfound' for executor 'notfound' not in PATH",
+            "ERROR:".red()
+        )))
+        .failure();
+}
+
 #[cfg(windows)]
 #[test]
 fn powershell() {


### PR DESCRIPTION
This is just a minor thing so I thought I might as well open a PR and see what you think.

### Problem

Currently, when you use languages for code blocks that are either not handled (e.g. I tried shell instead of sh in the beginning) or for which the executor program (like node for js) is missing you receive an error like:

```
> mask foo
ERROR: No such file or directory (os error 2)
```

For me this was kinda misleading when starting to use the tool.

### Describe the solution
That's why I added some error mapping which translates it to:

```
> cargo run -- foo
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/mask foo`
ERROR: program 'node' for executor 'js' not in PATH
```

### Testing code

The definition that I used for testing is:
````md
## foo

```js
console.log("bar")
```
````

### Other example

For other programs the new error message might look like:

```
> cargo run -- lel
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/mask lel`
ERROR: program 'shell' for executor 'shell' not in PATH
```

which doesn't look great but I still think it's better than the current error.