### PR TITLE
ci: add sha256 checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-unknown-linux-gnu
-          NAME=mask-$TARGET
+          NAME=mask-$VERSION_TAG-$TARGET
           mkdir $NAME
           mv ./target/$TARGET/release/mask ./$NAME/mask
           chmod +x ./$NAME/mask
@@ -144,7 +144,7 @@ jobs:
         run: |
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-pc-windows-msvc
-          NAME=mask-$VERSION_TAG-$TARGET
+          NAME=mask-$TARGET
           mkdir $NAME
           mv ./target/$TARGET/release/mask.exe ./$NAME/mask.exe
           7z a $NAME.zip $NAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,10 @@ jobs:
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-unknown-linux-gnu
           NAME=mask-$VERSION_TAG-$TARGET
-          INCLUDE_NAME=mask-$TARGET
-          mkdir $INCLUDE_NAME
-          mv ./target/$TARGET/release/mask ./$INCLUDE_NAME/mask
-          chmod +x ./$INCLUDE_NAME/mask
-          zip -r $NAME.zip $INCLUDE_NAME
+          mkdir $NAME
+          mv ./target/$TARGET/release/mask ./$NAME/mask
+          chmod +x ./$NAME/mask
+          zip -r $NAME.zip $NAME
           shasum -a 256 $NAME.zip > $NAME.zip.sha256
       - name: Attach the binary to the release
         uses: ./.github/actions/attach-release-assets
@@ -52,11 +51,10 @@ jobs:
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-unknown-linux-musl
           NAME=mask-$VERSION_TAG-$TARGET
-          INCLUDE_NAME=mask-$TARGET
-          mkdir $INCLUDE_NAME
-          mv ./target/$TARGET/release/mask ./$INCLUDE_NAME/mask
-          chmod +x ./$INCLUDE_NAME/mask
-          zip -r $NAME.zip $INCLUDE_NAME
+          mkdir $NAME
+          mv ./target/$TARGET/release/mask ./$NAME/mask
+          chmod +x ./$NAME/mask
+          zip -r $NAME.zip $NAME
           shasum -a 256 $NAME.zip > $NAME.zip.sha256
       - name: Attach the binary to the release
         uses: ./.github/actions/attach-release-assets
@@ -93,11 +91,10 @@ jobs:
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=aarch64-apple-darwin
           NAME=mask-$VERSION_TAG-$TARGET
-          INCLUDE_NAME=mask-$TARGET
-          mkdir $INCLUDE_NAME
-          mv ./target/$TARGET/release/mask ./$INCLUDE_NAME/mask
-          chmod +x ./$INCLUDE_NAME/mask
-          zip -r $NAME.zip $INCLUDE_NAME
+          mkdir $NAME
+          mv ./target/$TARGET/release/mask ./$NAME/mask
+          chmod +x ./$NAME/mask
+          zip -r $NAME.zip $NAME
           shasum -a 256 $NAME.zip > $NAME.zip.sha256
       # NOTE: cannot use the attach-release-assets action because macOS doesn't support docker-based actions.
       # Luckily we can just run the bash script directly.
@@ -130,11 +127,10 @@ jobs:
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-apple-darwin
           NAME=mask-$VERSION_TAG-$TARGET
-          INCLUDE_NAME=mask-$TARGET
-          mkdir $INCLUDE_NAME
-          mv ./target/$TARGET/release/mask ./$INCLUDE_NAME/mask
-          chmod +x ./$INCLUDE_NAME/mask
-          zip -r $NAME.zip $INCLUDE_NAME
+          mkdir $NAME
+          mv ./target/$TARGET/release/mask ./$NAME/mask
+          chmod +x ./$NAME/mask
+          zip -r $NAME.zip $NAME
           shasum -a 256 $NAME.zip > $NAME.zip.sha256
       # NOTE: cannot use the attach-release-assets action because macOS doesn't support docker-based actions.
       # Luckily we can just run the bash script directly.
@@ -175,10 +171,9 @@ jobs:
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-pc-windows-msvc
           NAME=mask-$VERSION_TAG-$TARGET
-          INCLUDE_NAME=mask-$TARGET
-          mkdir $INCLUDE_NAME
-          mv ./target/$TARGET/release/mask.exe ./$INCLUDE_NAME/mask.exe
-          7z a $NAME.zip $INCLUDE_NAME
+          mkdir $NAME
+          mv ./target/$TARGET/release/mask.exe ./$NAME/mask.exe
+          7z a $NAME.zip $NAME
           certutil -hashfile $NAME.zip sha256 | grep -E [A-Fa-f0-9]{64} > $NAME.zip.sha256
       # NOTE: cannot use the attach-release-assets action because windows doesn't support docker-based actions.
       # Luckily we can just run the bash script directly.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,24 @@ jobs:
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-unknown-linux-gnu
           NAME=mask-$VERSION_TAG-$TARGET
+          INCLUDE_NAME=mask-$TARGET
           mkdir $NAME
-          mv ./target/$TARGET/release/mask ./$NAME/mask
-          chmod +x ./$NAME/mask
-          zip -r $NAME.zip $NAME
+          mv ./target/$TARGET/release/mask ./$INCLUDE_NAME/mask
+          chmod +x ./$INCLUDE_NAME/mask
+          zip -r $NAME.zip $INCLUDE_NAME
+          shasum -a 256 $NAME.zip > $NAME.zip.sha256
       - name: Attach the binary to the release
         uses: ./.github/actions/attach-release-assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           assets: ./*.zip
+      - name: Attach the binary to the release
+        uses: ./.github/actions/attach-release-assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          assets: ./*.sha256
   
   release-linux-musl:
     runs-on: ubuntu-latest
@@ -44,16 +52,24 @@ jobs:
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-unknown-linux-musl
           NAME=mask-$VERSION_TAG-$TARGET
-          mkdir $NAME
-          mv ./target/$TARGET/release/mask ./$NAME/mask
-          chmod +x ./$NAME/mask
-          zip -r $NAME.zip $NAME
+          INCLUDE_NAME=mask-$TARGET
+          mkdir $INCLUDE_NAME
+          mv ./target/$TARGET/release/mask ./$INCLUDE_NAME/mask
+          chmod +x ./$INCLUDE_NAME/mask
+          zip -r $NAME.zip $INCLUDE_NAME
+          shasum -a 256 $NAME.zip > $NAME.zip.sha256
       - name: Attach the binary to the release
         uses: ./.github/actions/attach-release-assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           assets: ./*.zip
+      - name: Attach the binary to the release
+        uses: ./.github/actions/attach-release-assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          assets: ./*.sha256
 
   release-macos-aarch64:
     runs-on: macos-latest
@@ -77,14 +93,21 @@ jobs:
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=aarch64-apple-darwin
           NAME=mask-$VERSION_TAG-$TARGET
-          mkdir $NAME
-          mv ./target/$TARGET/release/mask ./$NAME/mask
-          chmod +x ./$NAME/mask
-          zip -r $NAME.zip $NAME
+          INCLUDE_NAME=mask-$TARGET
+          mkdir $INCLUDE_NAME
+          mv ./target/$TARGET/release/mask ./$INCLUDE_NAME/mask
+          chmod +x ./$INCLUDE_NAME/mask
+          zip -r $NAME.zip $INCLUDE_NAME
+          shasum -a 256 $NAME.zip > $NAME.zip.sha256
       # NOTE: cannot use the attach-release-assets action because macOS doesn't support docker-based actions.
       # Luckily we can just run the bash script directly.
       - name: Attach the binary to the release
         run: ./.github/actions/attach-release-assets/run.sh ./*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attach the binary to the release
+        shell: bash
+        run: ./.github/actions/attach-release-assets/run.sh ./*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -107,14 +130,21 @@ jobs:
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-apple-darwin
           NAME=mask-$VERSION_TAG-$TARGET
-          mkdir $NAME
-          mv ./target/$TARGET/release/mask ./$NAME/mask
-          chmod +x ./$NAME/mask
-          zip -r $NAME.zip $NAME
+          INCLUDE_NAME=mask-$TARGET
+          mkdir $INCLUDE_NAME
+          mv ./target/$TARGET/release/mask ./$INCLUDE_NAME/mask
+          chmod +x ./$INCLUDE_NAME/mask
+          zip -r $NAME.zip $INCLUDE_NAME
+          shasum -a 256 $NAME.zip > $NAME.zip.sha256
       # NOTE: cannot use the attach-release-assets action because macOS doesn't support docker-based actions.
       # Luckily we can just run the bash script directly.
       - name: Attach the binary to the release
         run: ./.github/actions/attach-release-assets/run.sh ./*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attach the binary to the release
+        shell: bash
+        run: ./.github/actions/attach-release-assets/run.sh ./*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -144,10 +174,11 @@ jobs:
         run: |
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-pc-windows-msvc
-          NAME=mask-$TARGET
-          mkdir $NAME
-          mv ./target/$TARGET/release/mask.exe ./$NAME/mask.exe
-          7z a $NAME.zip $NAME
+          NAME=mask-$VERSION_TAG-$TARGET
+          INCLUDE_NAME=mask-$TARGET
+          mkdir $INCLUDE_NAME
+          mv ./target/$TARGET/release/mask.exe ./$INCLUDE_NAME/mask.exe
+          7z a $NAME.zip $INCLUDE_NAME
           certutil -hashfile $NAME.zip sha256 | grep -E [A-Fa-f0-9]{64} > $NAME.zip.sha256
       # NOTE: cannot use the attach-release-assets action because windows doesn't support docker-based actions.
       # Luckily we can just run the bash script directly.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           TARGET=x86_64-unknown-linux-gnu
           NAME=mask-$VERSION_TAG-$TARGET
           INCLUDE_NAME=mask-$TARGET
-          mkdir $NAME
+          mkdir $INCLUDE_NAME
           mv ./target/$TARGET/release/mask ./$INCLUDE_NAME/mask
           chmod +x ./$INCLUDE_NAME/mask
           zip -r $NAME.zip $INCLUDE_NAME

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,10 +148,16 @@ jobs:
           mkdir $NAME
           mv ./target/$TARGET/release/mask.exe ./$NAME/mask.exe
           7z a $NAME.zip $NAME
+          certutil -hashfile $NAME.zip sha256 | grep -E [A-Fa-f0-9]{64} > $NAME.zip.sha256
       # NOTE: cannot use the attach-release-assets action because windows doesn't support docker-based actions.
       # Luckily we can just run the bash script directly.
       - name: Attach the binary to the release
         shell: bash
         run: ./.github/actions/attach-release-assets/run.sh ./*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attach the binary to the release
+        shell: bash
+        run: ./.github/actions/attach-release-assets/run.sh ./*.sha256
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           assets: ./*.zip
-      - name: Attach the binary to the release
+      - name: Attach the checksums to the release
         uses: ./.github/actions/attach-release-assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           assets: ./*.zip
-      - name: Attach the binary to the release
+      - name: Attach the checksums to the release
         uses: ./.github/actions/attach-release-assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -105,7 +105,7 @@ jobs:
         run: ./.github/actions/attach-release-assets/run.sh ./*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Attach the binary to the release
+      - name: Attach the checksums to the release
         shell: bash
         run: ./.github/actions/attach-release-assets/run.sh ./*.sha256
         env:
@@ -142,7 +142,7 @@ jobs:
         run: ./.github/actions/attach-release-assets/run.sh ./*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Attach the binary to the release
+      - name: Attach the checksums to the release
         shell: bash
         run: ./.github/actions/attach-release-assets/run.sh ./*.sha256
         env:
@@ -187,7 +187,7 @@ jobs:
         run: ./.github/actions/attach-release-assets/run.sh ./*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Attach the binary to the release
+      - name: Attach the checksums to the release
         shell: bash
         run: ./.github/actions/attach-release-assets/run.sh ./*.sha256
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           VERSION_TAG=$(jq --raw-output '.release.tag_name' "$GITHUB_EVENT_PATH")
           TARGET=x86_64-unknown-linux-gnu
-          NAME=mask-$VERSION_TAG-$TARGET
+          NAME=mask-$TARGET
           mkdir $NAME
           mv ./target/$TARGET/release/mask ./$NAME/mask
           chmod +x ./$NAME/mask


### PR DESCRIPTION
I want to create a scoop install manifest, but the version inside the zipped folder is pretty uncommon, the usual way is `$app_name-$target_platform` with the zip, can we please rename it?

It would be also lovely, if we could add SHA256 hashes to the release, do you want me to add that as well in this PR?