### PR TITLE
feat: add nix flake support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ pids
 
 # Dependency directory
 node_modules
+
+#######################################
+# direnv
+#######################################
+.direnv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,5 @@ members = [
     "mask",
     "mask-parser",
 ]
+
+resolver = "2"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703089493,
+        "narHash": "sha256-WUjYqUP/Lhhop9+aiHVFREgElunx1AHEWxqMT8ePfzo=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2a5136f14a9ac93d9d370d64a36026c5de3ae8a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1703134684,
+        "narHash": "sha256-SQmng1EnBFLzS7WSRyPM9HgmZP2kLJcPAz+Ug/nug6o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d6863cbcbbb80e71cecfc03356db1cda38919523",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -58,7 +58,31 @@
       "inputs": {
         "crane": "crane",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703297543,
+        "narHash": "sha256-d4QlzcoSNzb/iZheWtjOyRxoBSaLETSpViENGEkxv9g=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "fc77c8b416b1537522d30c710baaaaebf769f816",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Build a cargo project without extra checks";
+  description = "A CLI task runner defined by a simple markdown file";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
@@ -44,9 +44,6 @@
         };
 
         devShells.default = craneLib.devShell {
-          packages = [
-            # pkgs.ripgrep
-          ];
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "Build a cargo project without extra checks";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    crane = {
+      url = "github:ipetkov/crane";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, crane, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        craneLib = crane.lib.${system};
+        my-crate = craneLib.buildPackage {
+          src = craneLib.cleanCargoSource (craneLib.path ./.);
+          pname = "mask";
+          version = "0.11.4";
+          strictDeps = true;
+          doCheck = false;
+
+          buildInputs = [
+            # Add additional build inputs here
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+            # Additional darwin specific inputs can be set here
+            pkgs.libiconv
+          ];
+
+          # Additional environment variables can be set directly
+          # MY_CUSTOM_VAR = "some value";
+        };
+      in
+      {
+        packages.default = my-crate;
+
+        apps.default = flake-utils.lib.mkApp {
+          drv = my-crate;
+        };
+
+        devShells.default = craneLib.devShell {
+          packages = [
+            # pkgs.ripgrep
+          ];
+        };
+      });
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+profile="default"
+channel="1.74.0"
+components = ["rust-src"]


### PR DESCRIPTION
### Describe the solution

Nix is a package manager which, technically, can handle build in any language.

This `flake.nix` file is basically giving all the steps to build and import mask in their own flakes.

People can then, with the `nix` package manager, use mask right from this repository:

```bash
nix run "github:jacobdeichert/mask" -- --help
```

You can test it with my PR repository:

```bash
nix run "github:bachrc/mask" -- --help
```

Even if Mask is already available on the [nixpkgs repository](https://search.nixos.org/packages?channel=23.11&show=mask&from=0&size=50&sort=relevance&type=packages&query=mask), but this flake remove any dependency on the nixpkgs repository system (time for the PR to be merged, etc.)

This flake also allows to have a dev environment with every needed dependency : 

```bash
nix develop "github:jacobdeichert/mask"
```

The `.envrc` file enables integration with [`direnv`]("github:jacobdeichert/mask"), which basically triggers a `nix develop` when entering the folder (and then sets up the right build inputs versions)

I added a `rust-toolchain.toml` file which specifies the rust version needed to build the project. The nix flake is based on it in order to build it.

Your project is really great and I'm happy to contribute in any way to it! Please contact me if you need any changes