### PR TITLE
Fix php tests on macos actions runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        # Test on macos-13 because the macos-14 runner doesn't come with php installed.
+        platform: [ubuntu-latest, windows-latest, macos-13]
     env:
       CLICOLOR_FORCE: 1
     steps:


### PR DESCRIPTION

<!--
Please review our Contribution Guidelines (CONTRIBUTING.md) before creating an issue or submitting a PR 🙌
-->

### Which issue does this fix?

GitHub Actions `macos-latest` runner has been updated to macOS 14. However, that runner no longer comes pre-installed with php (see list [here](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md)).


### Describe the solution

For now, the easiest route is to just use the `macos-13` image instead which is what we were relying upon up until they changed "latest" to 14.
