### PR TITLE
Add choices list

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ echo "Total: $(($price * $TAX))"
 ~~~
 ```
 
-Set `type` to `enum`, and add a `choices` list, `mask` will validate if the flag value is one of the choices list.
+If you add a `choices` list, `mask` will validate if the flag value is one of them.
 
 **Example:**
 
@@ -166,7 +166,7 @@ Set `type` to `enum`, and add a `choices` list, `mask` will validate if the flag
 **OPTIONS**
 * color
     * flags: -c --color
-    * type: enum
+    * type: string
     * choices: RED, BLUE, GREEN
     * desc: Color of the text.
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,28 @@ echo "Total: $(($price * $TAX))"
 ~~~
 ```
 
+Set `type` to `enum`, and add a `choices` list, `mask` will validate if the flag value is one of the choices list.
+
+**Example:**
+
+`````markdown
+## print (text)
+
+> Print text with color
+
+**OPTIONS**
+* color
+    * flags: -c --color
+    * type: enum
+    * choices: RED, BLUE, GREEN
+    * desc: Color of the text.
+
+```sh
+COLOR=${color:RED} # Fallback to RED if not supplied
+echo "$COLOR: $text"
+```
+`````
+
 If you exclude the `type` field, `mask` will treat it as a `boolean` flag. If the flag is passed, its environment variable will be `"true"`, otherwise it will be unset/non-existent.
 
 Important to note that `mask` auto injects a very common `boolean` flag called `verbose` into every single command even if it's not used, which saves a bit of typing for you. This means every command implicitly has a `-v` and `--verbose` flag already.

--- a/mask-parser/src/maskfile.rs
+++ b/mask-parser/src/maskfile.rs
@@ -57,6 +57,8 @@ impl Command {
                 takes_value: false,
                 required: false,
                 validate_as_number: false,
+                validate_as_enum: false,
+                choices: vec![],
                 val: "".to_string(),
             });
         }
@@ -107,6 +109,8 @@ pub struct NamedFlag {
     pub multiple: bool,           // Can it have multiple values? (-vvv OR -i one -i two)
     pub takes_value: bool,        // Does it take a value? (-i value)
     pub validate_as_number: bool, // Should we validate it as a number?
+    pub validate_as_enum: bool,   // Should we validete it as a enum variant name?
+    pub choices: Vec<String>,     // Variants names if this flag is a enum.
     pub required: bool,
     /// Used within mask. TODO: store in a different place within mask instead of here.
     #[serde(skip)]
@@ -124,6 +128,8 @@ impl NamedFlag {
             takes_value: false,
             required: false,
             validate_as_number: false,
+            validate_as_enum: false,
+            choices: vec![],
             val: "".to_string(),
         }
     }

--- a/mask-parser/src/maskfile.rs
+++ b/mask-parser/src/maskfile.rs
@@ -57,7 +57,6 @@ impl Command {
                 takes_value: false,
                 required: false,
                 validate_as_number: false,
-                validate_as_enum: false,
                 choices: vec![],
                 val: "".to_string(),
             });
@@ -109,8 +108,7 @@ pub struct NamedFlag {
     pub multiple: bool,           // Can it have multiple values? (-vvv OR -i one -i two)
     pub takes_value: bool,        // Does it take a value? (-i value)
     pub validate_as_number: bool, // Should we validate it as a number?
-    pub validate_as_enum: bool,   // Should we validete it as a enum variant name?
-    pub choices: Vec<String>,     // Variants names if this flag is a enum.
+    pub choices: Vec<String>,     // Choices of flag value.
     pub required: bool,
     /// Used within mask. TODO: store in a different place within mask instead of here.
     #[serde(skip)]
@@ -128,7 +126,6 @@ impl NamedFlag {
             takes_value: false,
             required: false,
             validate_as_number: false,
-            validate_as_enum: false,
             choices: vec![],
             val: "".to_string(),
         }

--- a/mask-parser/src/parser.rs
+++ b/mask-parser/src/parser.rs
@@ -117,11 +117,6 @@ pub fn parse(maskfile_contents: String) -> Maskfile {
                             if val == "number" {
                                 current_option_flag.validate_as_number = true;
                             }
-
-                            if val == "enum" {
-                                current_option_flag.validate_as_enum = true;
-                                current_option_flag.takes_value = true;
-                            }
                         }
                         // Parse out the short and long flag names
                         "flags" => {
@@ -310,7 +305,6 @@ mod parse {
             "takes_value": false,
             "required": false,
             "validate_as_number": false,
-            "validate_as_enum": false,
             "choices": [],
         });
 

--- a/mask-parser/src/parser.rs
+++ b/mask-parser/src/parser.rs
@@ -117,6 +117,11 @@ pub fn parse(maskfile_contents: String) -> Maskfile {
                             if val == "number" {
                                 current_option_flag.validate_as_number = true;
                             }
+
+                            if val == "enum" {
+                                current_option_flag.validate_as_enum = true;
+                                current_option_flag.takes_value = true;
+                            }
                         }
                         // Parse out the short and long flag names
                         "flags" => {
@@ -134,6 +139,12 @@ pub fn parse(maskfile_contents: String) -> Maskfile {
                                     current_option_flag.short = name.to_string();
                                 }
                             }
+                        }
+                        "choices" => {
+                            current_option_flag.choices = val
+                                .split(',')
+                                .map(|choice| choice.trim().to_owned())
+                                .collect();
                         }
                         "required" => {
                             current_option_flag.required = true;
@@ -299,6 +310,8 @@ mod parse {
             "takes_value": false,
             "required": false,
             "validate_as_number": false,
+            "validate_as_enum": false,
+            "choices": [],
         });
 
         assert_eq!(

--- a/mask/src/main.rs
+++ b/mask/src/main.rs
@@ -184,6 +184,18 @@ fn get_command_options(mut cmd: Command, matches: &ArgMatches) -> Command {
                 .unwrap()
                 .to_string();
 
+            if !flag.choices.is_empty() {
+                if !flag.choices.iter().any(|choice| choice == &raw_value) {
+                    eprintln!(
+                        "{} flag `{}` expects one of {:?}",
+                        "ERROR:".red(),
+                        flag.name,
+                        flag.choices,
+                    );
+                    std::process::exit(1);
+                }
+            }
+
             if flag.validate_as_number && raw_value != "" {
                 // Try converting to an integer or float to validate it
                 if raw_value.parse::<isize>().is_err() && raw_value.parse::<f32>().is_err() {
@@ -191,18 +203,6 @@ fn get_command_options(mut cmd: Command, matches: &ArgMatches) -> Command {
                         "{} flag `{}` expects a numerical value",
                         "ERROR:".red(),
                         flag.name
-                    );
-                    std::process::exit(1);
-                }
-            }
-
-            if flag.validate_as_enum {
-                if !flag.choices.iter().any(|choice| choice == &raw_value) {
-                    eprintln!(
-                        "{} flag `{}` expects one of {:?}",
-                        "ERROR:".red(),
-                        flag.name,
-                        flag.choices,
                     );
                     std::process::exit(1);
                 }

--- a/mask/src/main.rs
+++ b/mask/src/main.rs
@@ -196,6 +196,18 @@ fn get_command_options(mut cmd: Command, matches: &ArgMatches) -> Command {
                 }
             }
 
+            if flag.validate_as_enum {
+                if !flag.choices.iter().any(|choice| choice == &raw_value) {
+                    eprintln!(
+                        "{} flag `{}` expects one of {:?}",
+                        "ERROR:".red(),
+                        flag.name,
+                        flag.choices,
+                    );
+                    std::process::exit(1);
+                }
+            }
+
             raw_value
         } else {
             // Check if the boolean flag is present and set to "true".

--- a/mask/tests/arguments_and_flags_test.rs
+++ b/mask/tests/arguments_and_flags_test.rs
@@ -177,6 +177,76 @@ Write-Output $sum
     }
 }
 
+mod enum_option_flag {
+    use super::*;
+
+    #[test]
+    fn properly_validates_flag_with_type_enum() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## color
+
+**OPTIONS**
+* val
+    * flags: --val
+    * type: enum
+    * choices: RED, BLUE, GREEN
+
+~~~bash
+echo "Value: $val"
+~~~
+
+~~~powershell
+param (
+    $in = $env:val
+)
+Write-Output "Value: $in"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("color --val RED")
+            .assert()
+            .stdout(contains("Value: RED"))
+            .success();
+    }
+
+    #[test]
+    fn out_of_choices() {
+        let (_temp, maskfile_path) = common::maskfile(
+            r#"
+## color
+
+**OPTIONS**
+* val
+    * flags: --val
+    * type: enum
+    * choices: RED, BLUE, GREEN
+
+~~~bash
+echo "Value: $val"
+~~~
+
+~~~powershell
+param (
+    $in = $env:val
+)
+Write-Output "Value: $in"
+~~~
+"#,
+        );
+
+        common::run_mask(&maskfile_path)
+            .cli("color --val YELLOW")
+            .assert()
+            .stderr(contains(
+                "flag `val` expects one of [\"RED\", \"BLUE\", \"GREEN\"]",
+            ))
+            .failure();
+    }
+}
+
 mod numerical_option_flag {
     use super::*;
 

--- a/mask/tests/arguments_and_flags_test.rs
+++ b/mask/tests/arguments_and_flags_test.rs
@@ -177,11 +177,11 @@ Write-Output $sum
     }
 }
 
-mod enum_option_flag {
+mod choices {
     use super::*;
 
     #[test]
-    fn properly_validates_flag_with_type_enum() {
+    fn properly_validates_flag_with_choices() {
         let (_temp, maskfile_path) = common::maskfile(
             r#"
 ## color
@@ -189,19 +189,19 @@ mod enum_option_flag {
 **OPTIONS**
 * val
     * flags: --val
-    * type: enum
+    * type: string
     * choices: RED, BLUE, GREEN
 
-~~~bash
+```bash
 echo "Value: $val"
-~~~
+```
 
-~~~powershell
+```powershell
 param (
     $in = $env:val
 )
 Write-Output "Value: $in"
-~~~
+```
 "#,
         );
 
@@ -221,19 +221,19 @@ Write-Output "Value: $in"
 **OPTIONS**
 * val
     * flags: --val
-    * type: enum
+    * type: string
     * choices: RED, BLUE, GREEN
 
-~~~bash
+```bash
 echo "Value: $val"
-~~~
+```
 
-~~~powershell
+```powershell
 param (
     $in = $env:val
 )
 Write-Output "Value: $in"
-~~~
+```
 "#,
         );
 

--- a/mask/tests/introspect_test.rs
+++ b/mask/tests/introspect_test.rs
@@ -27,7 +27,6 @@ echo something
         "takes_value": false,
         "required": false,
         "validate_as_number": false,
-        "validate_as_enum": false,
         "choices": [],
     });
 

--- a/mask/tests/introspect_test.rs
+++ b/mask/tests/introspect_test.rs
@@ -27,6 +27,8 @@ echo something
         "takes_value": false,
         "required": false,
         "validate_as_number": false,
+        "validate_as_enum": false,
+        "choices": [],
     });
 
     let expected_json = json!({


### PR DESCRIPTION
If we add a "choices" list to a `mask` task flag, and if flag value is not one of the choices, this task will fail.

### Which issue does this fix?

This is discussed in issue #91.

I don't add filepath and dirpath in this PR, I think this might need more discussion.

### Describe the solution

Before pass arguments to scripts, I check if this flag value shows in the choices list.
