### PR TITLE
feat(executor): add Go support with go-mask

### DIFF
--- a/mask/build.rs
+++ b/mask/build.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+fn main() {
+    // Check if `go` binary is available
+    if let Err(e) = Command::new("go").arg("version").output() {
+        panic!("Go is not installed or not in the PATH: {}", e);
+    }
+
+    // Run `go get` to install the required Go package
+    let status = Command::new("go")
+        .args(["install", "github.com/fr12k/go-mask@latest"])
+        .status()
+        .expect("Failed to execute `go install`");
+
+    if !status.success() {
+        panic!("`go install` command failed. Please check your Go setup.");
+    }
+
+    println!("cargo:rerun-if-changed=build.rs"); // Re-run if this file changes
+}

--- a/mask/go-mask.go
+++ b/mask/go-mask.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+    "fmt"
+    "os"
+)
+
+func main() {
+    fmt.Println("Hello, " + os.Getenv("name") + "!")
+}
+

--- a/mask/src/executor.rs
+++ b/mask/src/executor.rs
@@ -63,6 +63,11 @@ fn prepare_command(cmd: &Command) -> process::Command {
             child.arg("-r").arg(source);
             child
         }
+        "go" | "golang" => {
+            let mut child = process::Command::new("go-mask");
+            child.arg("-c").arg(source);
+            child
+        }
         #[cfg(windows)]
         "cmd" | "batch" => {
             let mut child = process::Command::new("cmd.exe");

--- a/mask/tests/supported_runtimes_test.rs
+++ b/mask/tests/supported_runtimes_test.rs
@@ -233,3 +233,38 @@ echo "Hello, " . $name . "!\n";
         .stdout(contains("Hello, World!"))
         .success();
 }
+
+#[test]
+fn go() {
+    //check if go-mask is installed
+    let output = std::process::Command::new("go-mask")
+        .arg("-h")
+        .output()
+        .expect("Failed to execute `go-mask -h`. Is Go installed?");
+    assert!(output.status.success(), "Go is not installed on the system.");
+
+    let (_temp, maskfile_path) = common::maskfile(
+        r#"
+## go
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+)
+
+func main() {
+    fmt.Println("Hello, " + os.Getenv("name") + "!")
+}
+```
+"#,
+    );
+
+    common::run_mask(&maskfile_path)
+        .command("go")
+        .env("name", "World")
+        .assert()
+        .stdout(contains("Hello, World!"))
+        .success();
+}


### PR DESCRIPTION
## ✨ Add Go Code Execution Support via `go-mask`

This update adds support for executing Go (`golang`) code blocks using the new [go-mask](https://github.com/fr12k/go-mask) tool. It brings Go in line with other supported languages in the executor, enabling seamless handling of Go snippets.

Go’s standard toolchain doesn’t support running code directly from the command line or via stdin. To address this, I developed [go-mask](https://github.com/fr12k/go-mask) a lightweight utility designed to fill that gap and make inline Go execution possible.

### Which issue does this fix?

Closes #118

### Describe the solution

The solution is to leverage the [go-mask](https://github.com/fr12k/go-mask) binary to execute any Go (`go` or `golang`) code block directly.  

### 🛠️ What’s changed

- Integrated `go-mask` into the executor runtime.
- Enables execution of both `go` and `golang` code fences.
- Adds `go-mask` as a build/runtime dependency.