### PR TITLE
Add display_choices option to display choices when running mask help

### DIFF
--- a/mask-parser/src/maskfile.rs
+++ b/mask-parser/src/maskfile.rs
@@ -60,6 +60,7 @@ impl Command {
                 required: false,
                 validate_as_number: false,
                 choices: vec![],
+                display_choices: false,
                 val: "".to_string(),
             });
         }
@@ -129,6 +130,7 @@ pub struct NamedFlag {
     pub validate_as_number: bool, // Should we validate it as a number?
     pub choices: Vec<String>,     // Choices of flag value.
     pub required: bool,
+    pub display_choices: bool, // Display choices in the description
     /// Used within mask. TODO: store in a different place within mask instead of here.
     #[serde(skip)]
     pub val: String,
@@ -146,6 +148,7 @@ impl NamedFlag {
             required: false,
             validate_as_number: false,
             choices: vec![],
+            display_choices: false,
             val: "".to_string(),
         }
     }

--- a/mask/tests/introspect_test.rs
+++ b/mask/tests/introspect_test.rs
@@ -28,6 +28,7 @@ echo something
         "required": false,
         "validate_as_number": false,
         "choices": [],
+        "display_choices": false,
     });
 
     let expected_json = json!({


### PR DESCRIPTION
### Which issue does this fix?
<!-- Replace 126 with the issue number you've fixed -->

Closes #126



### Describe the solution
Added `display_choices` param to choices that adds possible choices to the description that is printed when running `mask help`
